### PR TITLE
Fix/issues : CourtController - Parameter in `getCourtsContainsParam` can be controlled by the user

### DIFF
--- a/src/main/java/fashionable/simba/yanawacortapi/application/CourtApplicationService.java
+++ b/src/main/java/fashionable/simba/yanawacortapi/application/CourtApplicationService.java
@@ -7,7 +7,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 @Service

--- a/src/main/java/fashionable/simba/yanawacortapi/ui/CourtController.java
+++ b/src/main/java/fashionable/simba/yanawacortapi/ui/CourtController.java
@@ -9,8 +9,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.IllegalFormatCodePointException;
 import java.util.List;
 import java.util.UUID;
 import java.util.regex.Pattern;

--- a/src/test/java/fashionable/simba/yanawacortapi/domain/CourtServiceTest.java
+++ b/src/test/java/fashionable/simba/yanawacortapi/domain/CourtServiceTest.java
@@ -8,9 +8,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.sql.SQLDataException;
-import java.sql.SQLException;
-import java.sql.SQLNonTransientException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;


### PR DESCRIPTION
Fix/issues : CourtController - Parameter in `getCourtsContainsParam` can be controlled by the user

### 문제 상황
SonarCloud를 이용해 오염 분석을 진행하니 Parameter가 사용자에 의해 제어될 수 있다는 문제가 발생했습니다. 모든 사용자가 나쁜 방식으로 요청을 보내지 않지만 일부는 사용자의 정보, 암호 및 판매할 수 있는 모든 것에 액세스하려고 시스템을 감염시키려 한다. 그래서 모든 사용자의 데이터를 소독해야 할 필요가 있습니다.

### 참고 자료
[이 글](https://stackoverflow.com/questions/29796778/java-spring-securing-a-parameter-pathvariable)에서 입력 값을 안전하게 받기 위해서는 SQL 주입이 되고 있는지 사전에 확인해 예방하고, HTTP 인코딩을 조심할 필요가 있다고 합니다. 중요한 부분은 원하지 않는 문자의 입력을 가려서 받을 수 있지만 항상 그렇듯이 까다롭고 데이터가 사용되는 용도에 따라 다르기 때문에 원하는 값만 받을 수 있도록 설정할 필요가 있습니다.

### 해결
`getCourtsContainsParam` 메서드에서 필요한 값은 한글 뿐이므로 한글만 받을 수 있도록 설정했습니다. 그리고 유한 상태 머신인 Pattern을 미리 캐싱해 재사용 가능하도록 구현했습니다.

```java
private final Pattern pattern = Pattern.compile("^[가-힣\\s]*$");

@GetMapping("/v1/api/courts")
public ResponseEntity<List<CourtResponse>> getCourtsContainsParam(@RequestParam(required = false) String param) {
    if (param == null || param.isBlank()) {
        throw new IllegalStateException("공백이 들어올 수는 없습니다.");
    }

    if (!pattern.matcher(param).matches()) {
        throw new IllegalArgumentException("입력 값은 한글만 가능합니다.");
    }

    log.debug("Request to find list, Param is {}", param);

    return ResponseEntity.ok(courtApplicationService.findCourt(param).stream()
        .map(
            court -> new CourtResponse(court.getId(), court.getRegion() + court.getName())
        ).collect(Collectors.toList())
    );
}
```