### PR TITLE
Refact/domainservice : saveCourts 메서드 수정 및 트랜잭션 처리

### DIFF
--- a/src/main/java/fashionable/simba/yanawacortapi/domain/CourtRepository.java
+++ b/src/main/java/fashionable/simba/yanawacortapi/domain/CourtRepository.java
@@ -13,4 +13,8 @@ public interface CourtRepository {
 
     List<Court> findAll();
 
+    void deleteAllInBatch();
+
+    long count();
+
 }

--- a/src/main/java/fashionable/simba/yanawacortapi/domain/CourtService.java
+++ b/src/main/java/fashionable/simba/yanawacortapi/domain/CourtService.java
@@ -19,6 +19,7 @@ public class CourtService {
         this.courtRepository = courtRepository;
     }
 
+    @Transactional
     public List<Court> saveCourts(List<Court> courts) {
         if (courtRepository.count() > 0L) {
             log.debug("Delete all in Repository");
@@ -34,15 +35,18 @@ public class CourtService {
         }
     }
 
+    @Transactional(readOnly = true)
     public Court findCourt(UUID id) {
         return courtRepository.findById(id)
             .orElseThrow(() -> new NoCourtDataException("코트장 정보가 존재하지 않습니다."));
     }
 
+    @Transactional(readOnly = true)
     public List<Court> findCourts(String params) {
         return courtRepository.findCourtByAreaNameContainingOrPlaceNameContainingOrderByAreaNameAsc(params, params);
     }
 
+    @Transactional(readOnly = true)
     public List<Court> findCourts() {
         return courtRepository.findAll();
     }

--- a/src/main/java/fashionable/simba/yanawacortapi/domain/CourtService.java
+++ b/src/main/java/fashionable/simba/yanawacortapi/domain/CourtService.java
@@ -4,6 +4,7 @@ import fashionable.simba.yanawacortapi.exception.NoCourtDataException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
@@ -19,6 +20,11 @@ public class CourtService {
     }
 
     public List<Court> saveCourts(List<Court> courts) {
+        if (courtRepository.count() > 0L) {
+            log.debug("Delete all in Repository");
+            courtRepository.deleteAllInBatch();
+        }
+
         log.debug("Save court in Repository");
         try {
             return courtRepository.saveAll(courts);

--- a/src/main/java/fashionable/simba/yanawacortapi/infra/JpaCourtRepository.java
+++ b/src/main/java/fashionable/simba/yanawacortapi/infra/JpaCourtRepository.java
@@ -21,4 +21,10 @@ public interface JpaCourtRepository extends JpaRepository<Court, Long>, CourtRep
 
     @Override
     List<Court> findAll();
+
+    @Override
+    void deleteAllInBatch();
+
+    @Override
+    long count();
 }

--- a/src/main/java/fashionable/simba/yanawacortapi/ui/CourtController.java
+++ b/src/main/java/fashionable/simba/yanawacortapi/ui/CourtController.java
@@ -49,7 +49,7 @@ public class CourtController {
 
         return ResponseEntity.ok(courtApplicationService.findCourts(param).stream()
             .map(
-                court -> new CourtResponse(court.getId(), court.getAreaName() + court.getPlaceName(), court.getImagePath())
+                court -> new CourtResponse(court.getId(), String.format("%s %s", court.getAreaName(), court.getPlaceName()), court.getImagePath())
             ).collect(Collectors.toList())
         );
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 feign.client.config.default.connect-timeout=30000
 feign.client.config.default.read-timeout=30000
+logging.level.fashionable.simba.yanawacortapi=debug

--- a/src/test/java/fashionable/simba/yanawacortapi/domain/CourtServiceTest.java
+++ b/src/test/java/fashionable/simba/yanawacortapi/domain/CourtServiceTest.java
@@ -134,4 +134,23 @@ class CourtServiceTest {
         // then
         verify(courtRepository, atLeast(1)).findAll();
     }
+
+
+    @Test
+    @DisplayName("데이터가 하나 이상 존재하면 내부 데이터를 삭제하고 다시 저장한다.")
+    void test7() {
+        // given
+        List<Court> 코트장_리스트 = Arrays.asList(
+            new Court(null, "성동구", "응봉공원", null),
+            new Court(null, "양천구", "목동운동장>다목적구장", null)
+        );
+
+        //when
+        when(courtRepository.count()).thenReturn(3L);
+        courtService.saveCourts(코트장_리스트);
+
+        // then
+        verify(courtRepository, atLeast(1)).deleteAllInBatch();
+        verify(courtRepository, atLeast(1)).saveAll(코트장_리스트);
+    }
 }


### PR DESCRIPTION
- saveCourts에서 데이터가 존재할 경우 전부 삭제하고 다시 저장했습니다.
  - deleteAll() 메서드가 아닌 deleteAllInBatch() 메서드를 사용해서 삭제에서 시간을 단축할 수 있도록 구현했습니다.
- 트랜잭션 처리를 진행했습니다.